### PR TITLE
Avoid hissing sound in Headphones

### DIFF
--- a/configs/audio/mixer_paths_bcm.xml
+++ b/configs/audio/mixer_paths_bcm.xml
@@ -881,7 +881,7 @@
         <ctl name="HPHR Volume" value="20" />
         <ctl name="RX1 Digital Volume" value="60" />
         <ctl name="RX2 Digital Volume" value="60" />
-        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP1 Switch" value="0" />
     </path>
 
     <path name="headphones-advanced">
@@ -896,7 +896,7 @@
         <ctl name="HPHR Volume" value="20" />
         <ctl name="RX1 Digital Volume" value="57" />
         <ctl name="RX2 Digital Volume" value="57" />
-        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP1 Switch" value="0" />
     </path>
 
     <path name="headphones-aux">

--- a/configs/audio/mixer_paths_qcwcn.xml
+++ b/configs/audio/mixer_paths_qcwcn.xml
@@ -899,7 +899,7 @@
         <ctl name="HPHR Volume" value="20" />
         <ctl name="RX1 Digital Volume" value="60" />
         <ctl name="RX2 Digital Volume" value="60" />
-        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP1 Switch" value="0" />
     </path>
 
     <path name="headphones-advanced">
@@ -914,7 +914,7 @@
         <ctl name="HPHR Volume" value="20" />
         <ctl name="RX1 Digital Volume" value="57" />
         <ctl name="RX2 Digital Volume" value="57" />
-        <ctl name="COMP1 Switch" value="1" />
+        <ctl name="COMP1 Switch" value="0" />
     </path>
 
     <path name="headphones-aux">


### PR DESCRIPTION
Change the value of "COMP1 Switch" to 0 as described here:
 https://forum.xda-developers.com/showpost.php?p=59601465&postcount=150

This will avoid the hissing sound in the headphones on some of the G3's. You can compare and here this best with classicalmusic or some slow music.